### PR TITLE
Add support for unsecured Cloudant connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/IBM-Swift/CloudConfiguration.svg?branch=develop)](https://travis-ci.org/IBM-Swift/CloudConfiguration)
+[![Build Status](https://travis-ci.org/IBM-Swift/CloudConfiguration.svg?branch=master)](https://travis-ci.org/IBM-Swift/CloudConfiguration)
 ![macOS](https://img.shields.io/badge/os-macOS-green.svg?style=flat)
 ![Linux](https://img.shields.io/badge/os-linux-green.svg?style=flat)
 

--- a/Sources/CloudFoundryConfig/Services.swift
+++ b/Sources/CloudFoundryConfig/Services.swift
@@ -140,11 +140,11 @@ public class CloudantService: Service {
             let host      = credentials["host"] as? String,
             let username  = credentials["username"] as? String,
             let password  = credentials["password"] as? String,
-            let secured: Bool   = credentials["secured"] as? Bool ?? true,
             let port      = credentials["port"] as? Int,
             let url       = credentials["url"] as? String else {
                 return nil
         }
+        let secured: Bool = credentials["secured"] as? Bool ?? true
 
         self.host     = host
         self.username = username

--- a/Sources/CloudFoundryConfig/Services.swift
+++ b/Sources/CloudFoundryConfig/Services.swift
@@ -131,6 +131,7 @@ public class CloudantService: Service {
     public let username    : String
     public let password    : String
     public let port        : Int
+    public let secured     : Bool
     public let url         : String
 
     public init?(withService service: Service) {
@@ -139,6 +140,7 @@ public class CloudantService: Service {
             let host      = credentials["host"] as? String,
             let username  = credentials["username"] as? String,
             let password  = credentials["password"] as? String,
+            let secured: Bool   = credentials["secured"] as? Bool ?? true,
             let port      = credentials["port"] as? Int,
             let url       = credentials["url"] as? String else {
                 return nil
@@ -147,6 +149,7 @@ public class CloudantService: Service {
         self.host     = host
         self.username = username
         self.password = password
+        self.secured  = secured
         self.port     = port
         self.url      = url
 


### PR DESCRIPTION
Currently apps that use CloudConfiguration to configure a CouchDB/Cloudant instance can't (easily) use a local CouchDB for development. This is because a default CouchDB install is unsecured, and an unsecured connection isn't supported by CloudConfiguration.

This fixes that, allowing the `config.json` to set `secured: false` to use a local debug environment, whilst defaulting to `secured: true` if its not set.

Note that the change gives the following compilation warning:
```
Sources/CloudFoundryConfig/Services.swift:143:13: warning: non-optional expression of type 'Bool' used in a check for optionals
            let secured: Bool   = credentials["secured"] as? Bool ?? true,
            ^                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
but there doesn't seem to be an obvious was of avoiding it (not explicitly typing as Bool gives an even worse error!).