### PR TITLE
fix: extract push region from url

### DIFF
--- a/Sources/CloudEnvironment/PushSDKCredentials.swift
+++ b/Sources/CloudEnvironment/PushSDKCredentials.swift
@@ -17,14 +17,18 @@
 /// PushSDKCredentials class
 ///
 /// Contains the credentials for a PushSDK service instance.
+import Foundation
+
 public class PushSDKCredentials {
 
   public let appGuid      : String
   public let appSecret    : String
+  public let region       : String
 
-  public init(appGuid: String, appSecret: String) {
+  public init(appGuid: String, appSecret: String, region: String) {
     self.appGuid        = appGuid
     self.appSecret      = appSecret
+    self.region         = region
   }
 
 }
@@ -38,11 +42,27 @@ extension CloudEnv {
 
     guard let credentials = getDictionary(name: name),
       let appGuid = credentials["appGuid"] as? String ?? credentials["app_guid"] as? String,
-      let appSecret = credentials["appSecret"] as? String ?? credentials["app_secret"] as? String else {
+      let appSecret = credentials["appSecret"] as? String ?? credentials["app_secret"] as? String,
+      let pushURL = credentials["url"] as? String,
+      let url = URL(string: pushURL),
+      let region = getRegion(from: url)
+      else {
         return nil
     }
 
-    return PushSDKCredentials(appGuid: appGuid, appSecret: appSecret)
+    return PushSDKCredentials(appGuid: appGuid, appSecret: appSecret, region: region)
   }
 
+  private func getRegion(from url: URL) -> String? {
+    guard let host = url.host,
+      host.hasSuffix(".bluemix.net")
+    else{
+      return nil
+    }
+    let parts = host.split(separator: ".").suffix(3)
+    guard parts.count > 2 && parts.first != "imfpush" else {
+      return nil
+    }
+    return parts.joined(separator: ".")
+  }
 }

--- a/Tests/CloudEnvironmentTests/PushSDKTests.swift
+++ b/Tests/CloudEnvironmentTests/PushSDKTests.swift
@@ -35,9 +35,9 @@ class PushSDKTests: XCTestCase {
             XCTFail("Could not load Push SDK credentials.")
             return
         }
-
         XCTAssertEqual(credentials.appGuid, "push-appGuid", "PushSDK service appGuid should match.")
         XCTAssertEqual(credentials.appSecret, "push-secret", "PushSDK service appSecret should match.")
+        XCTAssertEqual(credentials.region, "ng.bluemix.net", "PushSDK service region should match.")
     }
 
 }


### PR DESCRIPTION
Parsing the URL from the PushNotifications Service to extract the region. e.g : `ng.bluemix.net`