### PR TITLE
remove logger from package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,12 +28,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", .upToNextMajor(from: "6.0.0")),
-        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [
         .target(
             name: "CloudEnvironment",
-            dependencies: ["CloudFoundryEnv", "LoggerAPI"]
+            dependencies: ["CloudFoundryEnv"]
         ),
         .testTarget(
             name: "CloudEnvironmentTests",


### PR DESCRIPTION
## Description
Logger was brought in by Swift-cfenv and so does not need to be explicitly declared in the package.swift file.

## How Has This Been Tested?
Swift test was run and all tests pass. This change should have no impact of code functionality.
