### PR TITLE
Load credentials of the `databases-for-postgresql` format

### DIFF
--- a/Sources/CloudEnvironment/PostgreSQLCredentials.swift
+++ b/Sources/CloudEnvironment/PostgreSQLCredentials.swift
@@ -63,4 +63,15 @@ extension CloudEnv {
     return PostgreSQLCredentials(uri: uri)
   }
 
+  public func getPostgreSQLDatabaseCredentials(name: String) -> PostgreSQLCredentials? {
+    guard let credentials = getDictionary(name: name),
+      let connection = credentials["connection"] as? [String: Any],
+      let postgres = connection["postgres"] as? [String: Any],
+      let composed = postgres["composed"] as? [String],
+      let uri = composed.first else {
+        return nil
+    }
+    return PostgreSQLCredentials(uri: uri)
+  }
+
 }

--- a/Sources/CloudEnvironment/PostgreSQLCredentials.swift
+++ b/Sources/CloudEnvironment/PostgreSQLCredentials.swift
@@ -47,6 +47,9 @@ extension CloudEnv {
 
   /// Returns an PostgreSQLCredentials object with the corresponding credentials.
   ///
+  /// This function retrieve the credentials for "Compose for PostgreSQL".
+  /// If you want to retrieve the credentials for "Databases for PostgreSQL",
+  /// use [getPostgreSQLDatabaseCredentials](x-source-tag://getPostgreSQLDatabaseCredentials).
   /// ### Usage Example: ###
   /// ```swift
   /// let cloudEnv = CloudEnv()
@@ -54,6 +57,7 @@ extension CloudEnv {
   /// credentials =  cloudEnv.getPostgreSQLCredentials(name: "PostgreSQLKey")
   /// ```
   /// - Parameter name: The key to lookup the environment variable.
+  /// - Tag: getPostgreSQLCredentials
   public func getPostgreSQLCredentials(name: String) -> PostgreSQLCredentials? {
     guard let credentials = getDictionary(name: name),
       let uri = credentials["uri"] as? String else {
@@ -63,6 +67,19 @@ extension CloudEnv {
     return PostgreSQLCredentials(uri: uri)
   }
 
+  /// Returns an PostgreSQLCredentials object with the corresponding credentials.
+  ///
+  /// This function retrieve the credentials for "Databases for PostgreSQL".
+  /// If you want to retrieve the credentials for "Compose for PostgreSQL",
+  /// use [getPostgreSQLCredentials](x-source-tag://getPostgreSQLCredentials).
+  /// ### Usage Example: ###
+  /// ```swift
+  /// let cloudEnv = CloudEnv()
+  ///
+  /// credentials = cloudEnv.getPostgreSQLDatabaseCredentials(name: "PostgreSQLKey")
+  /// ```
+  /// - Parameter name: The key to lookup the environment variable.
+  /// - Tag: getPostgreSQLDatabaseCredentials
   public func getPostgreSQLDatabaseCredentials(name: String) -> PostgreSQLCredentials? {
     guard let credentials = getDictionary(name: name),
       let connection = credentials["connection"] as? [String: Any],

--- a/Tests/CloudEnvironmentTests/PostgreSQLTests.swift
+++ b/Tests/CloudEnvironmentTests/PostgreSQLTests.swift
@@ -43,5 +43,23 @@ class PostgreSQLTests: XCTestCase {
         XCTAssertEqual(credentials.database, "compose", "PostgreSQL service database should match.")
 
     }
-
+    
+    func testGetCredentialsDB() {
+        
+        // Load test mappings.json file and Cloud Foundry test credentials-- VCAP_SERVICES and VCAP_APPLICATION
+        let cloudEnv = CloudEnv(mappingsFilePath: "Tests/CloudEnvironmentTests/resources", cloudFoundryFile: "Tests/CloudEnvironmentTests/resources/config_cf_example.json")
+        
+        guard let credentials =  cloudEnv.getPostgreSQLDatabaseCredentials(name: "PostgreSQLKey") else {
+            XCTFail("Could not load PostgreSQL credentials.")
+            return
+        }
+        
+        XCTAssertEqual(credentials.host, "123456789.123456789.databases.appdomain.cloud", "PostgreSQL service host should match.")
+        XCTAssertEqual(credentials.username, "ibm_cloud_1234", "PostgreSQL service username should match.")
+        XCTAssertEqual(credentials.password, "qwertyuiop", "PostgreSQL service password should match.")
+        XCTAssertEqual(credentials.port, 12345, "PostgreSQL service port should match.")
+        XCTAssertEqual(credentials.database, "dbname", "PostgreSQL service database should match.")
+        
+    }
+    
 }

--- a/Tests/CloudEnvironmentTests/PostgreSQLTests.swift
+++ b/Tests/CloudEnvironmentTests/PostgreSQLTests.swift
@@ -23,6 +23,7 @@ class PostgreSQLTests: XCTestCase {
     static var allTests : [(String, (PostgreSQLTests) -> () throws -> Void)] {
         return [
             ("testGetCredentials", testGetCredentials),
+            ("testGetCredentialsDB", testGetCredentialsDB),
         ]
     }
 
@@ -49,7 +50,7 @@ class PostgreSQLTests: XCTestCase {
         // Load test mappings.json file and Cloud Foundry test credentials-- VCAP_SERVICES and VCAP_APPLICATION
         let cloudEnv = CloudEnv(mappingsFilePath: "Tests/CloudEnvironmentTests/resources", cloudFoundryFile: "Tests/CloudEnvironmentTests/resources/config_cf_example.json")
         
-        guard let credentials =  cloudEnv.getPostgreSQLDatabaseCredentials(name: "PostgreSQLKey") else {
+        guard let credentials =  cloudEnv.getPostgreSQLDatabaseCredentials(name: "PostgreSQLKeyDB") else {
             XCTFail("Could not load PostgreSQL credentials.")
             return
         }

--- a/Tests/CloudEnvironmentTests/resources/config_cf_example.json
+++ b/Tests/CloudEnvironmentTests/resources/config_cf_example.json
@@ -202,6 +202,80 @@
         ]
       }
     ],
+    "databases-for-postgresql": [
+        {
+            "binding_name": null,
+            "credentials": {
+                "connection": {
+                    "cli": {
+                        "arguments": [
+                            [
+                                "host=123456789.123456789.databases.appdomain.cloud port=12345 dbname=dbname user=ibm_cloud_1234 sslmode=verify-full"
+                            ]
+                        ],
+                        "bin": "psql",
+                        "certificate": {
+                            "certificate_base64": "AAAAA",
+                            "name": "aaaa"
+                        },
+                        "composed": [
+                            "PGPASSWORD=qwerty PGSSLROOTCERT=aaaaaaaa-bbbb-cccc-cccc-dddddddddddd psql 'host=123456789.123456789.databases.appdomain.cloud port=12345 dbname=dbname user=ibm_cloud_1234 sslmode=verify-full'"
+                        ],
+                        "environment": {
+                            "PGPASSWORD": "qwertyuiop",
+                            "PGSSLROOTCERT": "aaaaaaaa-bbbb-cccc-cccc-dddddddddddd"
+                        },
+                        "type": "cli"
+                    },
+                    "postgres": {
+                        "authentication": {
+                            "method": "direct",
+                            "password": "qwertyuiop",
+                            "username": "ibm_cloud_1234"
+                        },
+                        "certificate": {
+                            "certificate_base64": "AAAA",
+                            "name": "aaaaaaaa-bbbb-cccc-cccc-dddddddddddd"
+                        },
+                        "composed": [
+                            "postgres://ibm_cloud_1234:qwertyuiop@123456789.123456789.databases.appdomain.cloud:12345/dbname?sslmode=verify-full"
+                        ],
+                        "database": "dbname",
+                        "hosts": [
+                            {
+                                "hostname": "123456789.123456789.databases.appdomain.cloud",
+                                "port": 12345
+                            }
+                        ],
+                        "path": "/dbname",
+                        "query_options": {
+                            "sslmode": "verify-full"
+                        },
+                        "scheme": "postgres",
+                        "type": "uri"
+                    }
+                },
+                "instance_administration_api": {
+                    "deployment_id": "crn:v1:bluemix:public:databases-for-postgresql:region:c/1234:1234::",
+                    "instance_id": "crn:v1:bluemix:public:databases-for-postgresql:region:c/1234:1234::",
+                    "root": "https://api.region.databases.cloud.ibm.com/v4/ibm"
+                }
+            },
+            "instance_name": "PostgreSQLService",
+            "label": "databases-for-postgresql",
+            "name": "PostgreSQLService",
+            "plan": "standard",
+            "provider": null,
+            "syslog_drain_url": null,
+            "tags": [
+                "data_management",
+                "ibm_created",
+                "rc_compatible",
+                "ibmcloud-alias"
+            ],
+            "volume_mounts": []
+        }
+    ],
     "cleardb": [
       {
         "credentials": {

--- a/Tests/CloudEnvironmentTests/resources/config_cf_example.json
+++ b/Tests/CloudEnvironmentTests/resources/config_cf_example.json
@@ -261,9 +261,9 @@
                     "root": "https://api.region.databases.cloud.ibm.com/v4/ibm"
                 }
             },
-            "instance_name": "PostgreSQLService",
+            "instance_name": "PostgreSQLServiceDB",
             "label": "databases-for-postgresql",
-            "name": "PostgreSQLService",
+            "name": "PostgreSQLServiceDB",
             "plan": "standard",
             "provider": null,
             "syslog_drain_url": null,

--- a/Tests/CloudEnvironmentTests/resources/mappings.json
+++ b/Tests/CloudEnvironmentTests/resources/mappings.json
@@ -108,13 +108,22 @@
     }
   },
   "PostgreSQLKey": {
-    "credentials": {
-      "searchPatterns": [
-        "cloudfoundry:PostgreSQLService",
-        "env:my-kube-secret-os-credentials",
-        "file:Tests/CloudEnvironmentTests/resources/config_cf_example.json"
-      ]
-    }
+      "credentials": {
+          "searchPatterns": [
+              "cloudfoundry:PostgreSQLService",
+              "env:my-kube-secret-os-credentials",
+              "file:Tests/CloudEnvironmentTests/resources/config_cf_example.json"
+          ]
+      }
+  },
+  "PostgreSQLKeyDB": {
+      "credentials": {
+          "searchPatterns": [
+              "cloudfoundry:PostgreSQLServiceDB",
+              "env:my-kube-secret-os-credentials",
+              "file:Tests/CloudEnvironmentTests/resources/config_cf_example.json"
+          ]
+      }
   },
   "MySQLKey": {
     "credentials": {


### PR DESCRIPTION
Add loading of CloudEnviroment credentials for PostgreSQL through the `databases-for-postgresql` format of Cloud Foundry.
The function `getPostgreSQLCredentials` is not working in such case.
A new test has been added.